### PR TITLE
stream.write accepts a callback..

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -70,8 +70,9 @@ app.use(ctx => {
     }
   })
   renderStream.on('end', () => {
-    stream.write(`<script src="${assets.main.js}"></script></body></html>`)
-    ctx.res.end()
+    stream.write(`<script src="${assets.main.js}"></script></body></html>`, () => {
+    ctx.res.end() 
+    })
   })
   renderStream.on('error', err => {
     throw new Error(`something bad happened when renderToStream: ${err}`)


### PR DESCRIPTION
I had an issue where the response was ended after writing to stream. It was a race condition where res.end fired before the stream write was completed. This was with a fairly large app that had a ton of components.